### PR TITLE
Update example and node version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,5 @@ build:
 		'--define:process.env.NODE_ENV="production"' \
 		--outdir=dist \
 		--platform=node \
-		--target=node12 \
+		--target=node16 \
 		./src/main.ts

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flytectl-setup-action
 
-This action sets up [flytectl](https://docs.flyte.org/projects/flytectl/en/stable/) for use in actions by:
+This action sets up [flytectl](https://docs.flyte.org/projects/flytectl/en/stable/) for use in actions.
 
 ## Usage
 
@@ -33,15 +33,17 @@ steps:
 
 ## Getting started Example
 ```bash
-steps:
-  - uses: actions/checkout@v2
-  - uses: unionai-oss/flytectl-setup-action@master
-  - name: Setup demo cluster
-    run: flytectl demo start
-  - name: Setup flytectl config
-    run: flytectl config init
-  - name: Register Core example
-    run: |
-      FLYTESNACKS_VERSION=$(curl --silent "https://api.github.com/repos/flyteorg/flytectl/releases/latest" | jq -r .tag_name)
-      flytectl register files -p flytesnacks -d development --archive https://github.com/flyteorg/flytesnacks/releases/download/$FLYTESNACKS_VERSION/flytesnacks-core.tgz  --version v1
+name: flytectl-setup-action
+on: [push]
+jobs:
+  install-flytectl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: unionai-oss/flytectl-setup-action@master
+      - name: Setup demo cluster
+        run: flytectl demo start
+      - name: Setup flytectl config
+        run: flytectl config init
+  
 ```

--- a/action.yml
+++ b/action.yml
@@ -7,5 +7,5 @@ inputs:
     required: false
     default: 'latest'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: './dist/main.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flytectl-setup-action",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Install and setup flytectl for use in other actions ",
   "main": "src/main.js",
   "scripts": {


### PR DESCRIPTION
Current example includes a step to register a Flytesnacks folder that doesn't exist and pulls the version from flytectl. This step not only fails but it's not needed for the actual purpose of the action.

Also, node12 is being deprecated.

This PRs fixes both issues.